### PR TITLE
Menu : toujours aff Paramètres, ne pas retirer viesco selon son index (bugait sous skolengo)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -96,6 +96,7 @@ export default defineComponent({
 	},
 	setup() {
 		// defines the tabs shown in the menu
+		// GLOBAL - Accueil
 		const appPages = [
 			{
 				title: 'Accueil',
@@ -104,13 +105,15 @@ export default defineComponent({
 				disabled: false
 			}
 		];
+
+		// SKOLENGO
 		if (localStorage.getItem("loginService") === "skolengo") {
 			appPages.push({
-				title: 'Emploi du temps',
-				url: '/timetable',
-				icon: "calendar_month",
-				disabled: false,
-			},
+					title: 'Emploi du temps',
+					url: '/timetable',
+					icon: "calendar_month",
+					disabled: false,
+				},
 				{
 					title: 'Travail à faire',
 					url: '/homework',
@@ -122,21 +125,17 @@ export default defineComponent({
 					url: '/news',
 					icon: "newspaper",
 					disabled: false,
-				},
-				{
-					title: 'Paramètres',
-					url: '/settings',
-					icon: "settings",
-					disabled: false
 				})
 		}
+
+		// PRONOTE
 		if (localStorage.getItem("loginService") === "pronote") {
 			appPages.push({
-				title: 'Emploi du temps',
-				url: '/timetable',
-				icon: "calendar_month",
-				disabled: false,
-			},
+					title: 'Emploi du temps',
+					url: '/timetable',
+					icon: "calendar_month",
+					disabled: false,
+				},
 				{
 					title: 'Travail à faire',
 					url: '/homework',
@@ -148,14 +147,17 @@ export default defineComponent({
 					url: '/grades',
 					icon: "insights",
 					disabled: false,
-				},
-				{
+				})
+
+			if (localStorage.getItem('viescolaireEnabled') == 'true') {
+				appPages.push({
 					title: 'Vie scolaire',
 					url: '/schoollife',
 					icon: "gavel",
 					disabled: false,
-				},
-				{
+				})
+			}
+			appPages.push({
 					title: 'Actualités',
 					url: '/news',
 					icon: "newspaper",
@@ -166,19 +168,10 @@ export default defineComponent({
 					url: '/conversations',
 					icon: "forum",
 					disabled: false,
-				},
-				{
-					title: 'Paramètres',
-					url: '/settings',
-					icon: "settings",
-					disabled: false
 				})
 		}
-		// hides some tabs when they are not anabled
-		if (localStorage.getItem('viescolaireEnabled') !== 'true') {
-			// remove school life tab
-			appPages.splice(4, 1);
-		}
+
+		// ECOLEDIRECTE
 		if (localStorage.getItem("loginService") === "ecoledirecte") {
 			let usercache = localStorage.getItem("UserCache");
 			if (usercache != null) {
@@ -258,14 +251,17 @@ export default defineComponent({
 							break;
 					}
 				})
-				appPages.push({
-					title: 'Paramètres',
-					url: '/settings',
-					icon: "settings",
-					disabled: false
-				})
+
 			}
 		}
+
+		// GLOBAL - Paramètres
+		appPages.push({
+			title: 'Paramètres',
+			url: '/settings',
+			icon: "settings",
+			disabled: false
+		})
 
 		const route = useRoute();
 


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] You can **build successfully** the whole project with your changes locally
- [x] You use the coding conventions and the **naming conventions** of the project
- [x] You use **tabs** for indentation
- [x] You make sure that your PR is **not a duplicate**
- [x] This PR is **ready** to be reviewed and merged
- [x] This PR merges into the **`development`** branch or in the specific branch of the feature you want to merge into
- [x] There is no **`TODO`** in the code
- [x] There is no spelling or grammatical errors in the code
- [x] Details of the issue or feature are documented below
- [x] This PR is **not** a **breaking change** (e.g. changes that would cause existing functionality to change)

## Proposed changelog

| Français `fr` |
| --- |
| Le menu affiche désomais Paramètres indépendamment du service (moins de code dupliqué) et l'onglet Vie Sco n'est plus retiré selon sa position (ce qui cachait l'onglet Paramètres avec Skolengo :>))|

### Note
Before merging this PR, you will need the approval of at least one of the following people:
- @ecnivtwelve
- @lucas-luchack

So be patient ;)

### Informations supplémentaires
