### PR TITLE
Afficher le groupe pour un cours dans l'emploi du temps

### DIFF
--- a/src/components/timetable/CoursElement.vue
+++ b/src/components/timetable/CoursElement.vue
@@ -28,6 +28,11 @@
 				required: false,
 				default: "Pas de salle",
 			},
+			groupNames: {
+				type: String,
+				required: false,
+				default: null,
+			},
 			memo: {
 				type: Boolean,
 				required: false,
@@ -102,6 +107,7 @@
 				coursPourcentVisible: false,
 				intervalUpdateProgressDiv: null,
 				showPastProgress: localStorage.getItem("tweakProgressBarShowPast") != "false",
+				disableShowGroup: localStorage.getItem('disableShowGroup'),
 			};
 		},
 		setup() {
@@ -258,17 +264,27 @@
 				<div class="CoursData">
 					<h3 class="CoursName">{{ subject }}</h3>
 
-					<div class="CoursInfoContainer">
-						<div class="CoursInfo room" v-if="rooms !== null">
-							<span class="material-symbols-outlined smol" slot="start">location_on</span>
+					<div>
+						<div class="CoursInfoContainer">
+							<div class="CoursInfo room" v-if="rooms !== null">
+								<span class="material-symbols-outlined smol" slot="start">location_on</span>
 
-							<p>{{ rooms }}</p>
+								<p>{{ rooms }}</p>
+							</div>
+							<div class="separator" v-if="rooms !== null"></div>
+							<div class="CoursInfo">
+								<span class="material-symbols-outlined smol" slot="start">face</span>
+
+								<p>{{ teachers }}</p>
+							</div>
 						</div>
-						<div class="separator" v-if="rooms !== null"></div>
-						<div class="CoursInfo">
-							<span class="material-symbols-outlined smol" slot="start">face</span>
 
-							<p>{{ teachers }}</p>
+						<div class="CoursInfoContainer" v-if="disableShowGroup == 'true' && groupNames !== null">
+							<div class="CoursInfo">
+								<span class="material-symbols-outlined smol" slot="start">groups</span>
+
+								<p>{{ groupNames.startsWith("[") ? groupNames.slice(1, -1).replace(/_/g, ' ') : groupNames.replace(/_/g, ' ') }}</p>
+							</div>
 						</div>
 					</div>
 

--- a/src/views/settings/OptionsView.vue
+++ b/src/views/settings/OptionsView.vue
@@ -155,9 +155,13 @@
 			let disableHolidays = this.$refs.disableHolidays;
 			disableHolidays.$el.checked = localStorage.getItem('disableHolidays') == 'true';
 
-			// get changePeriodSelection ref
+			// get disableConfetti ref
 			let disableConfetti = this.$refs.disableConfetti;
 			disableConfetti.$el.checked = localStorage.getItem('disableConfetti') == 'true';
+
+			// get disableShowGroup ref
+			let disableShowGroup = this.$refs.disableShowGroup;
+			disableShowGroup.$el.checked = localStorage.getItem('disableShowGroup') == 'true';
 		}
 	});
 </script>
@@ -234,6 +238,21 @@
 						<p>Active l'onglet de vie scolaire</p>
 					</IonLabel>
 					<IonToggle slot="end" ref="viescolaireEnabled" @ionChange="changeTick('viescolaireEnabled')"></IonToggle>
+				</IonItem>
+			</IonList>
+
+			<IonLabel class="listGroupTitle">
+				<p>Emploi du temps</p>
+			</IonLabel>
+
+			<IonList class="listGroup" lines="inset">
+				<IonItem>
+					<span class="material-symbols-outlined mdls" slot="start">groups</span>
+					<IonLabel class="ion-text-wrap">
+						<h2>Afficher le groupe pour les cours</h2>
+						<p>Autorise le groupe d'un cours à s'afficher dans l'emploi du temps</p>
+					</IonLabel>
+					<IonToggle slot="end" ref="disableShowGroup" @ionChange="changeTick('disableShowGroup')"></IonToggle>
 				</IonItem>
 			</IonList>
 

--- a/src/views/timetable/CoursView.vue
+++ b/src/views/timetable/CoursView.vue
@@ -74,7 +74,9 @@
 				openCours_time: [],
 				teachers: "",
 				rooms: "",
+				groupNames: "",
 				notificationEnabled: false,
+				disableShowGroup: localStorage.getItem('disableShowGroup'),
 			}
 		},
 		methods: {
@@ -386,6 +388,8 @@
 
 				this.teachers = parsed.data.teachers.join(', ');
 				this.rooms = parsed.data.rooms.join(', ');
+				this.groupNames = parsed.data.groupNames.join(', ');
+				this.groupNames = this.groupNames.startsWith("[") ? this.groupNames.slice(1, -1).replace(/_/g, ' ') : this.groupNames.replace(/_/g, ' ')
 
 				this.pageTitle = this.openCours_data.subject;
 
@@ -471,6 +475,13 @@
 						<ion-label>
 							<p>Salle</p>
 							<h2>{{rooms || "Pas de salle" }}</h2>
+						</ion-label>
+					</ion-item>
+					<ion-item class="info-item" v-if="disableShowGroup == 'true' && groupNames.length">
+						<span class="material-symbols-outlined mdls" slot="start">groups</span>
+						<ion-label>
+							<p>Groupe</p>
+							<h2>{{groupNames || "Pas de groupe" }}</h2>
 						</ion-label>
 					</ion-item>
 				</IonList>

--- a/src/views/timetable/TimetableView.vue
+++ b/src/views/timetable/TimetableView.vue
@@ -494,6 +494,7 @@
 				name: '',
 				teacher: '',
 				room: '',
+				groupNames: '',
 				start: '',
 				end: '',
 				length: '',
@@ -617,6 +618,7 @@
 							:subject="cours.data.subject"
 							:teachers="cours.data.teachers.join(', ') || 'Pas de professeur'"
 							:rooms="cours.data.rooms.join(', ') || 'Pas de salle'"
+							:groupNames="cours.data.groupNames.join('') || null"
 							:memo="cours.data.hasMemo"
 							:start="cours.time.start"
 							:end="cours.time.end"


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] You can **build successfully** the whole project with your changes locally
- [x] You use the coding conventions and the **naming conventions** of the project
- [x] You use **tabs** for indentation
- [x] You make sure that your PR is **not a duplicate**
- [x] This PR is **ready** to be reviewed and merged
- [x] This PR merges into the **`development`** branch or in the specific branch of the feature you want to merge into
- [x] There is no **`TODO`** in the code
- [x] There is no spelling or grammatical errors in the code
- [x] Details of the issue or feature are documented below
- [x] This PR is **not** a **breaking change** (e.g. changes that would cause existing functionality to change)

## Proposed changelog

| Français `fr` |
| --- |
| Dans l'emploi du temps, le groupe (genre groupe 1/groupe 2 ou la langue style espagnol/allemand) est affiché sous le nom du professeur et de la salle |
| Un paramètre a été ajouté pour ne pas afficher les groupes par défaut |

### Note
Before merging this PR, you will need the approval of at least one of the following people:
- @ecnivtwelve
- @lucas-luchack

So be patient ;)