### PR TITLE
🎨 Ajout d'un arrière-plan en dégradé linéaire à l'élément .nextStatus

### DIFF
--- a/src/views/homepage/HomepageView.vue
+++ b/src/views/homepage/HomepageView.vue
@@ -1075,7 +1075,7 @@ export default defineComponent({
 
 .nextStatus {
 	width: 100%;
-	background: var(--courseColor) !important;
+	background: linear-gradient(90deg, #00000055 0%, #00000055 100%), var(--courseColor) !important;
 
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] You can **build successfully** the whole project with your changes locally
- [x] You use the coding conventions and the **naming conventions** of the project
- [x] You use **tabs** for indentation
- [x] You make sure that your PR is **not a duplicate**
- [x] This PR is **ready** to be reviewed and merged
- [x] This PR merges into the **`development`** branch or in the specific branch of the feature you want to merge into
- [x] There is no **`TODO`** in the code
- [x] There is no spelling or grammatical errors in the code
- [x] Details of the issue or feature are documented below
- [x] This PR is **not** a **breaking change** (e.g. changes that would cause existing functionality to change)

## Explain changes
![Couleur](https://github.com/PapillonApp/Papillon/assets/69793084/f198a65b-3011-4736-b59f-8c3390b19bdd)
Lorsque la couleur d'un cours a un contraste trop faible on ne voit plus le texte.
![Avant](https://github.com/PapillonApp/Papillon/assets/69793084/42d23f8d-4eab-4ded-b5cd-1afac68b531c)

Ainsi dans le menu "Notes", un linear gradient a été ajouté pour éviter cela : 
![Notes](https://github.com/PapillonApp/Papillon/assets/69793084/643bbb38-3be8-4ad8-abab-54be22e1aab1)

Je veux faire de même pour la page d'accueil : 
![Après](https://github.com/PapillonApp/Papillon/assets/69793084/b49ff7b0-9ffd-494b-a4a1-12910e53442f)

## Proposed changelog

| Français `fr` |
| --- |
| 🎨 Ajout d'un arrière-plan en dégradé linéaire à l'élément .nextStatus |

### Note
Before merging this PR, you will need the approval of at least one of the following people:
- @ecnivtwelve
- @lucas-luchack

So be patient ;)

### Informations supplémentaires
